### PR TITLE
Add Remote AutoPlay via UDP Multicast

### DIFF
--- a/BigBoxAutoPlay/AutoPlayers/BigBoxAutoPlayer.cs
+++ b/BigBoxAutoPlay/AutoPlayers/BigBoxAutoPlayer.cs
@@ -256,20 +256,33 @@ namespace BigBoxAutoPlay.AutoPlayers
 
         public void LaunchGame()
         {
+            bool doLaunch = true;
+
             // bail out if we ain't got no settings
-            if (bigBoxAutoPlaySettings == null) return;
-
+            if (bigBoxAutoPlaySettings == null) 
+                doLaunch = false;
             // bail out if settings are disabled 
-            if (!bigBoxAutoPlaySettings.Enabled.GetValueOrDefault()) return;
-
-            // bail out if launch game is not checked
-            if (!bigBoxAutoPlaySettings.LaunchGame.GetValueOrDefault()) return;
-
+            else if (!bigBoxAutoPlaySettings.Enabled.GetValueOrDefault()) 
+                doLaunch = false;
+            // 
+            else if (bigBoxAutoPlaySettings.LaunchGame.GetValueOrDefault() == false)
+            {
+                // bail out if neither launch game or remote sync is set
+                if (bigBoxAutoPlaySettings.RemoteSync.GetValueOrDefault() == false)
+                    doLaunch = false;
+                // bail if we're syncing with remote, but the remote didn't
+                // issue a start game
+                else if (bigBoxAutoPlaySettings.RemoteSync.GetValueOrDefault() == true &&
+                         bigBoxAutoPlaySettings.GameState != GameStateEnum.GAME_LAUNCHED)
+                    doLaunch = false;
+            }
             // bail out if the game is not resolved 
-            if (resolvedGame == null) return;
+            else if (resolvedGame == null) 
+                doLaunch = false;
 
             // launch the game
-            PluginHelper.BigBoxMainViewModel.PlayGame(resolvedGame, null, null, null);
+            if (doLaunch)
+                PluginHelper.BigBoxMainViewModel.PlayGame(resolvedGame, null, null, null);
         }
     }
 }

--- a/BigBoxAutoPlay/BigBoxAutoPlay.csproj
+++ b/BigBoxAutoPlay/BigBoxAutoPlay.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\Users\Adam\Documents\LaunchBox\Plugins\&quot; /K /D /H /Y /E" />
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\LaunchBox\Plugins\&quot; /K /D /H /Y /E" />
   </Target>
 
 </Project>

--- a/BigBoxAutoPlay/DataAccess/BigBoxAutoPlaySettingsDataService.cs
+++ b/BigBoxAutoPlay/DataAccess/BigBoxAutoPlaySettingsDataService.cs
@@ -42,9 +42,13 @@ namespace BigBoxAutoPlay.DataAccess
                     FromPlatform = string.Empty,
                     SpecificGameId = string.Empty,
                     DelayInSeconds = 2,
-                    CreateServer = false,
-                    ServerIPAddress = "127.0.0.1",
-                    ServerPort = 50001                    
+                    ServerEnable = false,
+                    ServerPort = 50001,
+                    RemoteSync = false,
+                    RemoteIPAddress = "0.0.0.0",
+                    RemotePort = 50001,
+                    MulticastEnable = false,
+                    MulticastAddress = "224.1.1.1"            
                 };
 
                 // save the file 
@@ -80,10 +84,16 @@ namespace BigBoxAutoPlay.DataAccess
                     FromPlaylist = string.Empty,
                     FromPlatform = string.Empty,
                     SpecificGameId = string.Empty,
-                    
-                    CreateServer = false,
-                    ServerIPAddress = "127.0.0.1",
-                    ServerPort = 50001                    
+
+                    ServerEnable = false,
+                    ServerPort = 50001,
+
+                    RemoteSync = false,
+                    RemoteIPAddress = "0.0.0.0",
+                    RemotePort = 50001,
+
+                    MulticastEnable = false,
+                    MulticastAddress = "224.1.1.1"
                 };
 
                 // save the file 

--- a/BigBoxAutoPlay/Models/BigBoxAutoPlaySettings.cs
+++ b/BigBoxAutoPlay/Models/BigBoxAutoPlaySettings.cs
@@ -1,5 +1,8 @@
 ﻿namespace BigBoxAutoPlay.Models
 {
+    // Need until BigBox API provides an interface
+    public enum GameStateEnum { IDLE, GAME_LAUNCHED, GAME_EXITED }
+
     public class BigBoxAutoPlaySettings
     {
         // enabling functionality
@@ -17,13 +20,22 @@
         public string FromPlatform { get; set; }
         public string SpecificGameId { get; set; }
         
-        // server config
-        public bool? CreateServer { get; set; }
-        public string ServerIPAddress { get; set; }
-        public int? ServerPort { get; set; } 
+        // UDP server config
+        public bool? ServerEnable { get; set; }
+        public int? ServerPort { get; set; }
 
-        // additional parameters for launching game from TCP server
+        // UDP Remote Client config
+        public bool? RemoteSync { get; set; }
+        public string RemoteIPAddress { get; set; }
+        public int? RemotePort { get; set; }
+
+        // UDP Multicast config
+        public bool? MulticastEnable { get; set; }
+        public string MulticastAddress { get; set; }
+
+        // additional parameters for launching game from UDP server
         public string FromPlaylistName { get; set; }
-        public string GameTitle { get; set; }
+        public string GameTitle { get; set; }       
+        public GameStateEnum? GameState { get; set; }
     }
 }

--- a/BigBoxAutoPlay/ViewModels/BigBoxAutoPlaySetupViewModel.cs
+++ b/BigBoxAutoPlay/ViewModels/BigBoxAutoPlaySetupViewModel.cs
@@ -152,10 +152,16 @@ namespace BigBoxAutoPlay.ViewModels
             IncludeHidden = bigBoxAutoPlaySettings.IncludeHidden.GetValueOrDefault();
             IncludeBroken = bigBoxAutoPlaySettings.IncludeBroken.GetValueOrDefault();                                    
             DelayInSeconds = bigBoxAutoPlaySettings.DelayInSeconds.GetValueOrDefault();
-            CreateServer = bigBoxAutoPlaySettings.CreateServer.GetValueOrDefault();
-            
+
+            ServerEnable = bigBoxAutoPlaySettings.ServerEnable.GetValueOrDefault();            
             ServerPort = bigBoxAutoPlaySettings.ServerPort.GetValueOrDefault();
-            ServerIPAddress = bigBoxAutoPlaySettings.ServerIPAddress;
+
+            RemoteSync = bigBoxAutoPlaySettings.RemoteSync.GetValueOrDefault();
+            RemoteIPAddress = bigBoxAutoPlaySettings.RemoteIPAddress;
+            RemotePort = bigBoxAutoPlaySettings.RemotePort.GetValueOrDefault();
+
+            MulticastEnable = bigBoxAutoPlaySettings.MulticastEnable.GetValueOrDefault();
+            MulticastAddress = bigBoxAutoPlaySettings.MulticastAddress;
 
             if (!string.IsNullOrWhiteSpace(bigBoxAutoPlaySettings.FromPlatform))
             {
@@ -302,13 +308,13 @@ namespace BigBoxAutoPlay.ViewModels
             }
         }
 
-        public bool CreateServer
+        public bool ServerEnable
         {
-            get => bigBoxAutoPlaySettings?.CreateServer == true;
+            get => bigBoxAutoPlaySettings?.ServerEnable == true;
             set
             {
-                bigBoxAutoPlaySettings.CreateServer = value;
-                OnPropertyChanged("CreateServer");
+                bigBoxAutoPlaySettings.ServerEnable = value;
+                OnPropertyChanged("ServerEnable");
             }
         }
 
@@ -331,14 +337,52 @@ namespace BigBoxAutoPlay.ViewModels
                 OnPropertyChanged("ServerPort");
             }
         }
-
-        public string ServerIPAddress
+        public bool RemoteSync
         {
-            get => bigBoxAutoPlaySettings?.ServerIPAddress;
+            get => bigBoxAutoPlaySettings?.RemoteSync == true;
             set
             {
-                bigBoxAutoPlaySettings.ServerIPAddress = value;
-                OnPropertyChanged("ServerIPAddress");
+                bigBoxAutoPlaySettings.RemoteSync = value;
+                OnPropertyChanged("RemoteSync");
+            }
+        }
+
+        public string RemoteIPAddress
+        {
+            get => bigBoxAutoPlaySettings?.RemoteIPAddress;
+            set
+            {
+                bigBoxAutoPlaySettings.RemoteIPAddress = value;
+                OnPropertyChanged("RemoteIPAddress");
+            }
+        }
+
+        public int RemotePort
+        {
+            get => bigBoxAutoPlaySettings?.RemotePort ?? 0;
+            set
+            {
+                bigBoxAutoPlaySettings.RemotePort = value;
+                OnPropertyChanged("RemotePort");
+            }
+        }
+        public bool MulticastEnable
+        {
+            get => bigBoxAutoPlaySettings?.MulticastEnable == true;
+            set
+            {
+                bigBoxAutoPlaySettings.MulticastEnable = value;
+                OnPropertyChanged("MulticastEnable");
+            }
+        }
+
+        public string MulticastAddress
+        {
+            get => bigBoxAutoPlaySettings?.MulticastAddress;
+            set
+            {
+                bigBoxAutoPlaySettings.MulticastAddress = value;
+                OnPropertyChanged("MulticastAddress");
             }
         }
     }

--- a/BigBoxAutoPlay/Views/BigBoxAutoPlaySetupView.xaml
+++ b/BigBoxAutoPlay/Views/BigBoxAutoPlaySetupView.xaml
@@ -25,7 +25,7 @@
         </Grid.ColumnDefinitions>
 
         <Rectangle Grid.Row="1" Grid.Column="1" Fill="#4D4F61" Stretch="Fill" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"/>
-        <Rectangle Grid.Row="1" Grid.Column="1" Fill="#3F404E" Stretch="Fill" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="1"/>
+        <Rectangle Grid.Row="1" Grid.Column="1" Fill="#3F404E" Stretch="Fill" Margin="1,1,1,0" Grid.RowSpan="2"/>
 
         <Grid Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <Grid.RowDefinitions>
@@ -42,12 +42,12 @@
 
             <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="1">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="109"/>
+                    <ColumnDefinition Width="426*"/>
                     <ColumnDefinition Width="100"/>
-                    <ColumnDefinition Width="3*"/>
-                    <ColumnDefinition Width="100"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="145*"/>
+                    <ColumnDefinition Width="145*"/>
+                    <ColumnDefinition Width="145*"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -65,76 +65,92 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto" MinHeight="38.098"/>
+                    <RowDefinition Height="Auto" MinHeight="39"/>
+                    <RowDefinition Height="Auto" MinHeight="42"/>
+                    <RowDefinition Height="43*"/>
+                    <RowDefinition Height="50*"/>
                 </Grid.RowDefinitions>
 
-                <Label Grid.Row="0" Grid.Column="0" Content="Enable" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding Enabled, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Column="0" Content="Enable" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="45"/>
+                <CheckBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding Enabled, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="1" Grid.Column="0" Content="Select game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding SelectGame, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="1" Grid.Column="0" Content="Select game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="75"/>
+                <CheckBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding SelectGame, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="2" Grid.Column="0" Content="Show platform before selecting game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding ShowPlatformsBeforeSelectingGame, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="2" Content="Show platform before selecting game" Foreground="#D3D3D5" HorizontalAlignment="Center" VerticalAlignment="Center" Height="26" Width="86"/>
+                <CheckBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" IsChecked="{Binding ShowPlatformsBeforeSelectingGame, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="3" Grid.Column="0" Content="Launch game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding LaunchGame, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="3" Grid.Column="0" Content="Launch game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="81"/>
+                <CheckBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding LaunchGame, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="4" Grid.Column="0" Content="Only favorites" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding OnlyFavorites, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="4" Grid.Column="0" Content="Only favorites" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="83"/>
+                <CheckBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding OnlyFavorites, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="5" Grid.Column="0" Content="Hidden games" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding IncludeHidden, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="5" Content="Hidden games" Foreground="#D3D3D5" HorizontalAlignment="Center" VerticalAlignment="Center" Height="26" Width="86"/>
+                <CheckBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding IncludeHidden, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="6" Grid.Column="0" Content="Broken games" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding IncludeBroken, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="6" Content="Broken games" Foreground="#D3D3D5" HorizontalAlignment="Center" VerticalAlignment="Center" Height="26" Width="85"/>
+                <CheckBox Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding IncludeBroken, Mode=TwoWay}" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"/>
 
-                <Label Grid.Row="7" Grid.Column="0" Content="Platform" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <ComboBox Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2" Background="#343542" Foreground="#D3D3D5"
+                <Label Grid.Row="7" Grid.Column="0" Content="Platform" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="55"/>
+                <ComboBox Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"
                           ItemsSource="{Binding PlatformLookup}"
                           DisplayMemberPath="Name"
                           SelectedItem="{Binding SelectedPlatform, Mode=TwoWay}"/>
                 <Button Grid.Row="7" Grid.Column="4" Content="Clear" Command="{Binding ClearPlatformCommand}" 
-                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0" />
+                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0,0,4" Width="43" />
 
-                <Label Grid.Row="8" Grid.Column="0" Content="Playlist" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <ComboBox Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2" Background="#343542" Foreground="#D3D3D5"
+                <Label Grid.Row="8" Grid.Column="0" Content="Playlist" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="47"/>
+                <ComboBox Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"
                           ItemsSource="{Binding PlaylistLookup}"
                           DisplayMemberPath="Name"
                           SelectedItem="{Binding SelectedPlaylist, Mode=TwoWay}"/>
                 <Button Grid.Row="8" Grid.Column="4" Content="Clear" Command="{Binding ClearPlaylistCommand}" 
-                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0"/>
+                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0,0,2" Width="43"/>
 
-                <Label Grid.Row="9" Grid.Column="0" Content="Game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <ComboBox Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2" Background="#343542" Foreground="#D3D3D5"
+                <Label Grid.Row="9" Grid.Column="0" Content="Game" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="26" Width="41"/>
+                <ComboBox Grid.Row="9" Grid.Column="1" Grid.ColumnSpan="3" Margin="10,2,10,2" Background="#343542" Foreground="#D3D3D5"
                           ItemsSource="{Binding GameLookup}"
                           DisplayMemberPath="Title"
                           SelectedItem="{Binding SelectedGame, Mode=TwoWay}"/>
                 <Button Grid.Row="9" Grid.Column="4" Content="Clear" Command="{Binding ClearGameCommand}" 
-                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0" />
+                        HorizontalAlignment="Left" Background="#3F404E" Foreground="#D3D3D5" Margin="2,0,0,8" Width="43" />
 
-                <StackPanel Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="4" Margin="10,5"                             
-                            HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal">
+                <StackPanel Grid.Row="10" Grid.Column="0" Margin="10,0,0,0"                             
+                            HorizontalAlignment="Left" VerticalAlignment="Center" Orientation="Horizontal" Height="26" Width="69">
                     <Label Content="Delay" Foreground="#D3D3D5" VerticalAlignment="Bottom"/>
                     <Label Content="{Binding DelayInSeconds}" ContentStringFormat="N1" Margin="2,0" 
                            Foreground="#D3D3D5" VerticalAlignment="Bottom"/>
                     <Label Content="s" Foreground="#D3D3D5" VerticalAlignment="Bottom"/>
                 </StackPanel>
-                <Slider Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="4" Margin="20,5" Name="StartupLoadDelaySlider"                        
+                <Slider Grid.Row="11" Grid.Column="0" Grid.ColumnSpan="4" Margin="20,5,20,5" Name="StartupLoadDelaySlider"                        
                         Value="{Binding DelayInSeconds, Mode=TwoWay}"
-                        HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                         Minimum="0" Maximum="30" TickPlacement="BottomRight" TickFrequency="1" SmallChange="0.1" LargeChange="1.0"
                         IsSnapToTickEnabled="False"/>
 
-                <Label Grid.Row="12" Grid.Column="0" Content="Create server" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <CheckBox Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="4" IsChecked="{Binding CreateServer, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="12" Content="Server Enable" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Height="26" Width="109" Grid.ColumnSpan="2" Margin="10,0,0,0"/>
+                <CheckBox Grid.Row="12" Grid.Column="1" IsChecked="{Binding ServerEnable, Mode=TwoWay}" Margin="15,4,311,25" Background="#343542" Foreground="#D3D3D5" Grid.RowSpan="2"/>
 
-                <Label Grid.Row="13" Grid.Column="0" Content="Server IP" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <TextBox Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding ServerIPAddress, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="12" Content="Multicast Enable" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="137" Margin="213,2,0,0" Grid.Column="1" Grid.RowSpan="2"/>
+                <CheckBox Grid.Row="12" Grid.Column="1" IsChecked="{Binding MulticastEnable, Mode=TwoWay}" Margin="350,5,85,23" Background="#343542" Foreground="#D3D3D5" Grid.ColumnSpan="2" Grid.RowSpan="2"/>
 
-                <Label Grid.Row="14" Grid.Column="0" Content="Server port" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,2"/>
-                <TextBox Grid.Row="14" Grid.Column="1" Grid.ColumnSpan="4" Text="{Binding ServerPort, Mode=TwoWay}" Margin="10,2" Background="#343542" Foreground="#D3D3D5"/>
+                <Label Grid.Row="13" Grid.Column="0" Content="Server Port" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="25" Width="75"/>
+                <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding ServerPort, Mode=TwoWay}" Margin="15,0,311,2" Background="#343542" Foreground="#D3D3D5"/>
+
+                <Label Grid.Row="13" Grid.Column="1" Content="Multicast IP" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="213,0,0,0" Height="25" Width="122"/>
+                <TextBox Grid.Row="13" Grid.Column="1" Text="{Binding MulticastAddress, Mode=TwoWay}" Margin="350,0,76,2" Background="#343542" Foreground="#D3D3D5" Grid.ColumnSpan="2"/>
+
+                <Label Grid.Row="15" Content="Remote Sync" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Top" Height="26" Width="109" Grid.ColumnSpan="2" Margin="10,19,0,0" Grid.RowSpan="2"/>
+                <CheckBox Grid.Row="15" Grid.Column="1" IsChecked="{Binding RemoteSync, Mode=TwoWay}" Margin="15,17,311,6" Background="#343542" Foreground="#D3D3D5"/>
+
+                <Label Grid.Row="16" Grid.Column="0" Content="Remote IP" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,14,0,0" Height="25" Width="75"/>
+                <TextBox Grid.Row="16" Grid.Column="1" Text="{Binding RemoteIPAddress, Mode=TwoWay}" Margin="15,10,311,4" Background="#343542" Foreground="#D3D3D5" />
+
+                <Label Grid.Row="17" Grid.Column="0" Content="Remote Port" Foreground="#D3D3D5" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" Height="24" Width="75"/>
+                <TextBox Grid.Row="17" Grid.Column="1" Text="{Binding RemotePort, Mode=TwoWay}" Margin="15,8,311,9" Background="#343542" Foreground="#D3D3D5" />
+
+
             </Grid>
         </Grid>
 


### PR DESCRIPTION
Add ability to "sync" with a remote peer running BigBox. When a game launched on an instance of BigBox, the remote peer or multicast group is notified.  The remote peer or multicast group are also notified when a game is exited.  If configured, the remote peer(s) will be kept in sync by also launching or exiting the same game.

![Capture](https://github.com/user-attachments/assets/59d29b96-fa59-406e-901c-f142a264facf)

**Server Enable**
Enable UDP Server. UDP Server will bind to IP_ADDRESS_ANY (0.0.0.0)

**Server Port**
The Local port the UDP server will listen on.

**Remote Sync**
When set, BigBoxAutoPlay will take action when notified of a game starting or exiting on a remote peer.  If notified that a game has launched, it will AutoPlay the same game. If notified that a game has exited, it will exit the same game. Exiting in this context simply means sending the ESC keyboard event.  This requires a slight modification to the "Running Script" portion of certain emulators.  Add the following if the emulator doesn't already have it in "Running Script section. (TOOLS->Manage->Emulators-> (select your emulator) -> Running Script)

$Esc::
{
    WinClose, ahk_exe {{{StartupEXE}}}
}

Note: For MAME, ESC will immediately terminate the game when the on-screen menu is up.  Therefore, you may want to bind another key to menu back or launch the Mame64.exe outside of Launchbox when your still in the setup/configuration portion of your build.

**Multicast Enable**
When set, BigBoxAutoPlay will join the multicast group specified in the Multicast IP field.  Multicast range is 224.0.0.0 to 239.255.255.255.  Multicast will only work if the network has a querier.  Most often, this is handled by your router.    Game starting/exiting messages will be sent to this multicast group.

**Remote IP**
When not using multicast, the IP address of the remote peer.  Game starting/exiting messages will be sent to this address

**Remote Port**
The port the remote peer will listen on.
